### PR TITLE
QI-354 JdbmEntityStoreMixin restore does not work in Windows environments

### DIFF
--- a/extensions/entitystore-jdbm/src/main/java/org/qi4j/entitystore/jdbm/JdbmEntityStoreMixin.java
+++ b/extensions/entitystore-jdbm/src/main/java/org/qi4j/entitystore/jdbm/JdbmEntityStoreMixin.java
@@ -333,6 +333,8 @@ public class JdbmEntityStoreMixin
 
             // Import went ok - continue
             recordManager.commit();
+            // close file handles otherwise Microsoft Windows will fail to rename database files.
+            recordManager.close();
 
             lock.writeLock().lock();
             try


### PR DESCRIPTION
File handles are still open in MS Windows and the db file rename fails leaving you with deleted database files.

Solution: Do a recordmanager close before renaming temporary database file to actual database file.
