### PR TITLE
it is now possible to use classes with non-object constructor arguments ...

### DIFF
--- a/core/runtime/src/main/java/org/qi4j/runtime/composite/CompositeModel.java
+++ b/core/runtime/src/main/java/org/qi4j/runtime/composite/CompositeModel.java
@@ -14,12 +14,6 @@
 
 package org.qi4j.runtime.composite;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import org.qi4j.api.common.ConstructionException;
 import org.qi4j.api.common.MetaInfo;
 import org.qi4j.api.common.Visibility;
@@ -32,6 +26,12 @@ import org.qi4j.functional.VisitableHierarchy;
 import org.qi4j.runtime.injection.Dependencies;
 import org.qi4j.runtime.injection.DependencyModel;
 import org.qi4j.runtime.structure.ModuleInstance;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
 import static org.qi4j.functional.Iterables.first;
@@ -141,7 +141,7 @@ public abstract class CompositeModel
             ClassLoader proxyClassloader = mainType.getClassLoader();
 
             Class<?>[] interfaces = Iterables.toArray( Class.class, Iterables.<Class, Class<?>>cast( types ) );
-            proxyClass = (Class<? extends Composite>) Proxy.getProxyClass( proxyClassloader, interfaces );
+            proxyClass = (Class<? extends Composite>) ProxyGenerator.createProxyClass(proxyClassloader, interfaces);
 
             try
             {

--- a/core/runtime/src/main/java/org/qi4j/runtime/composite/ProxyGenerator.java
+++ b/core/runtime/src/main/java/org/qi4j/runtime/composite/ProxyGenerator.java
@@ -1,0 +1,16 @@
+package org.qi4j.runtime.composite;
+
+import java.lang.reflect.Proxy;
+
+/**
+ * generates proxyclasses
+ */
+public class ProxyGenerator {
+    public static Class<?> createProxyClass(ClassLoader mainTypeClassLoader, Class<?>[] interfaces) {
+        ClassLoader effectiveClassLoader = Thread.currentThread().getContextClassLoader();
+        if (effectiveClassLoader == null) {
+            effectiveClassLoader = mainTypeClassLoader;
+        }
+        return Proxy.getProxyClass(effectiveClassLoader, interfaces);
+    }
+}

--- a/core/runtime/src/main/java/org/qi4j/runtime/injection/provider/ThisInjectionProviderFactory.java
+++ b/core/runtime/src/main/java/org/qi4j/runtime/injection/provider/ThisInjectionProviderFactory.java
@@ -1,17 +1,19 @@
 package org.qi4j.runtime.injection.provider;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
 import org.qi4j.api.composite.CompositeDescriptor;
 import org.qi4j.api.util.Classes;
 import org.qi4j.bootstrap.InvalidInjectionException;
 import org.qi4j.functional.Iterables;
+import org.qi4j.runtime.composite.ProxyGenerator;
 import org.qi4j.runtime.injection.DependencyModel;
 import org.qi4j.runtime.injection.InjectionContext;
 import org.qi4j.runtime.injection.InjectionProvider;
 import org.qi4j.runtime.injection.InjectionProviderFactory;
 import org.qi4j.runtime.model.Resolution;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 
 import static org.qi4j.functional.Iterables.first;
 import static org.qi4j.functional.Iterables.iterable;
@@ -83,7 +85,7 @@ public final class ThisInjectionProviderFactory
                 {
                     Class<?> mainType = first( types );
                     interfaces = Iterables.toArray( Class.class, types );
-                    proxyClass = Proxy.getProxyClass( mainType.getClassLoader(), interfaces );
+                    proxyClass = ProxyGenerator.createProxyClass(mainType.getClassLoader(), interfaces);
                 }
 
                 proxyConstructor = proxyClass.getConstructor( InvocationHandler.class );

--- a/core/runtime/src/test/java/org/qi4j/runtime/composite/MapOverrideTest.java
+++ b/core/runtime/src/test/java/org/qi4j/runtime/composite/MapOverrideTest.java
@@ -16,10 +16,6 @@
 
 package org.qi4j.runtime.composite;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.qi4j.api.composite.Composite;
@@ -31,6 +27,12 @@ import org.qi4j.bootstrap.AssemblyException;
 import org.qi4j.bootstrap.ModuleAssembly;
 import org.qi4j.test.AbstractQi4jTest;
 
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -40,7 +42,7 @@ import static org.junit.Assert.assertThat;
  * Note that keySet(), values() and entrySet() would ALSO require overloading, but this has been left out for
  * clarity reasons.
  */
-@Ignore("Subclassing can not occur in java.* packages, and need to be prefixed.")
+//@Ignore("Subclassing can not occur in java.* packages, and need to be prefixed.")
 public class MapOverrideTest
     extends AbstractQi4jTest
 {
@@ -48,80 +50,112 @@ public class MapOverrideTest
     public void assemble( ModuleAssembly module )
         throws AssemblyException
     {
-        module.values( Map.class ).withMixins( HashMap.class ).withConcerns( ReadOnlyMapConcern.class );
+        // unable to add the concern, since it is applied on the prototype too!
+        // this seems to be a generic problem with prototypes.
+        module.values( Map.class ).withMixins( HashMap.class );//.withConcerns(ReadOnlyMapConcern.class);
     }
 
-    @Test @Ignore("Until we can override JDK classes in FragmentClassLoader" )
+    @Test @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingSizeExpectSuccess()
     {
         ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
         Map<String,String> prototype = builder.prototype();
         prototype.put( "Niclas", "Hedhman" );
-        Map<String,String> underTest = builder.newInstance();
-        assertThat( underTest.get( "Niclas" ), equalTo("Hedhman") );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.size(), equalTo(1) );
     }
 
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingIsEmptyExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.isEmpty(), equalTo(false) );
     }
-
+    
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingContainsKeyExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.containsKey("Niclas"), equalTo(true) );
     }
 
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingContainsValueExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.containsValue("Hedhman"), equalTo(true) );
     }
 
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingGetExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.get( "Niclas" ), equalTo("Hedhman") );
     }
 
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingKeySetExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        assertThat( underTest.keySet(), equalTo(Collections.singleton("Niclas")) );
     }
 
     @Test
+    @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingEntrySetExpectSuccess()
     {
-
     }
 
     @Test
     public void givenReadOnlyAnnotatedHashMapWhenCallingValuesExpectSuccess()
     {
-
+        ValueBuilder<Map> builder = module.newValueBuilder( Map.class );
+        Map<String,String> prototype = builder.prototype();
+        prototype.put( "Niclas", "Hedhman" );
+        Map<String,String> underTest =  builder.newInstance();
+        Collection<String> values = Collections.singletonList("Hedhman");
+        assertThat( underTest.values().size(), equalTo(values.size()) );
+        assertThat( underTest.values().contains("Hedhman"), equalTo(true) );
     }
 
     @Test( expected = ReadOnlyException.class )
+    @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingPutExpectReadOnlyException()
     {
 
     }
 
     @Test( expected = ReadOnlyException.class )
+    @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingRemoveExpectReadOnlyException()
     {
 
     }
 
     @Test( expected = ReadOnlyException.class )
+    @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingPutAllExpectReadOnlyException()
     {
 
     }
 
     @Test( expected = ReadOnlyException.class )
+    @Ignore
     public void givenReadOnlyAnnotatedHashMapWhenCallingClearExpectReadOnlyException()
     {
 


### PR DESCRIPTION
...and jdk classes as mixins

contains 2 changes:

1) some classloader changes making it possible to use jdk classes as mixins and creating composites for jdk interfaces

2) Makes it possible to use classes containing constructors with some primitive arguments (tested with int and float by using java.util.HashMap) as mixins.
